### PR TITLE
Add custom class creation

### DIFF
--- a/src/components/AddClassForm/AddClassForm.css
+++ b/src/components/AddClassForm/AddClassForm.css
@@ -1,0 +1,29 @@
+.add-class-form {
+  background: var(--element-background);
+  border-radius: 0.5rem;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+  margin-bottom: 1rem;
+  max-width: 30rem;
+  width: 100%;
+}
+
+.form__input-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+  text-align: left;
+}
+
+.form__input-group label {
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.form__input-group input {
+  background: var(--element-background);
+  border-radius: 0.5rem;
+  border: 1px solid var(--bluish-grey);
+  font-size: 1rem;
+  padding: 0.5rem;
+}

--- a/src/components/AddClassForm/AddClassForm.jsx
+++ b/src/components/AddClassForm/AddClassForm.jsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import Button from '../Button/Button';
+import './AddClassForm.css';
+
+const AddClassForm = ({ onAdd }) => {
+  const [course, setCourse] = useState('');
+  const [location, setLocation] = useState('');
+  const [time, setTime] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!course || !location || !time) return;
+    onAdd({ course, location, time });
+    setCourse('');
+    setLocation('');
+    setTime('');
+  };
+
+  return (
+    <form className="add-class-form" onSubmit={handleSubmit}>
+      <div className="form__input-group">
+        <label htmlFor="course">Course</label>
+        <input
+          id="course"
+          type="text"
+          value={course}
+          onChange={(e) => setCourse(e.target.value)}
+          required
+        />
+      </div>
+      <div className="form__input-group">
+        <label htmlFor="location">Location</label>
+        <input
+          id="location"
+          type="text"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          required
+        />
+      </div>
+      <div className="form__input-group">
+        <label htmlFor="time">Time</label>
+        <input
+          id="time"
+          type="text"
+          placeholder="10:00"
+          value={time}
+          onChange={(e) => setTime(e.target.value)}
+          required
+        />
+      </div>
+      <Button type="submit" buttonType="primary">
+        Add Class
+      </Button>
+    </form>
+  );
+};
+
+export default AddClassForm;

--- a/src/pages/ClassesPage/ClassesPage.jsx
+++ b/src/pages/ClassesPage/ClassesPage.jsx
@@ -1,27 +1,55 @@
 import './ClassesPage.css';
 import { useState, useEffect, useContext } from 'react';
 import Class from '../../components/Class/Class';
+import AddClassForm from '../../components/AddClassForm/AddClassForm';
 import CheckInContext from '../../context/CheckInContext';
+import { generateClassId } from '../../utils/generateClassId';
 
 const ClassesPage = () => {
   const [classes, setClasses] = useState([]);
   const { checkInObject, checkInTime, handleCheckInObject } =
     useContext(CheckInContext);
 
-  // Todo: Move this code to a custom hook
+  // Load classes from localStorage or fallback to bundled JSON
   useEffect(() => {
-    fetch('/data/classes.json')
-      .then((response) => response.json())
-      .then((data) => setClasses(data))
-      .catch((error) => console.error('Error loading classes:', error));
+    const storedClasses = localStorage.getItem('classes');
+    if (storedClasses) {
+      setClasses(JSON.parse(storedClasses));
+    } else {
+      fetch('/data/classes.json')
+        .then((response) => response.json())
+        .then((data) => {
+          setClasses(data);
+          localStorage.setItem('classes', JSON.stringify(data));
+        })
+        .catch((error) => console.error('Error loading classes:', error));
+    }
   }, []);
 
-  const handleSelectClass = (selectedClass) => {
-    handleCheckInObject(selectedClass);
+  // Persist classes to localStorage when they change
+  useEffect(() => {
+    if (classes.length) {
+      localStorage.setItem('classes', JSON.stringify(classes));
+    }
+  }, [classes]);
+
+const handleSelectClass = (selectedClass) => {
+  handleCheckInObject(selectedClass);
+};
+
+  const handleAddClass = ({ course, location, time }) => {
+    const newClass = {
+      id: generateClassId(),
+      course,
+      location,
+      time,
+    };
+    setClasses([...classes, newClass]);
   };
 
   return (
     <div className="classes__page">
+      <AddClassForm onAdd={handleAddClass} />
       <div className="classes__list">
         {classes.map((cls) => (
           <Class

--- a/src/utils/generateClassId.js
+++ b/src/utils/generateClassId.js
@@ -1,0 +1,1 @@
+export const generateClassId = () => Date.now();


### PR DESCRIPTION
## Summary
- allow users to add new classes in the Classes page
- store classes in local storage so they persist across sessions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687543450a808333891df2f0791b331c