### PR TITLE
Add ability to add classes

### DIFF
--- a/src/components/AddClassForm/AddClassForm.css
+++ b/src/components/AddClassForm/AddClassForm.css
@@ -1,0 +1,28 @@
+.add-class-form {
+  background: var(--element-background);
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  text-align: left;
+  width: 100%;
+  max-width: 30rem;
+}
+
+.add-class__group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 0.75rem;
+}
+
+.add-class__group label {
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.add-class__group input {
+  background: var(--element-background);
+  border: 1px solid var(--bluish-grey);
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  padding: 0.5rem;
+}

--- a/src/components/AddClassForm/AddClassForm.jsx
+++ b/src/components/AddClassForm/AddClassForm.jsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import Button from '../Button/Button';
+import './AddClassForm.css';
+
+const AddClassForm = ({ onAddClass }) => {
+  const [course, setCourse] = useState('');
+  const [location, setLocation] = useState('');
+  const [time, setTime] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    if (!course || !location || !time) return;
+
+    onAddClass({ course, location, time });
+    setCourse('');
+    setLocation('');
+    setTime('');
+  };
+
+  return (
+    <form className="add-class-form" onSubmit={handleSubmit}>
+      <div className="add-class__group">
+        <label htmlFor="course">Class Name:</label>
+        <input
+          id="course"
+          type="text"
+          value={course}
+          onChange={(e) => setCourse(e.target.value)}
+          required
+        />
+      </div>
+      <div className="add-class__group">
+        <label htmlFor="location">Location:</label>
+        <input
+          id="location"
+          type="text"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          required
+        />
+      </div>
+      <div className="add-class__group">
+        <label htmlFor="time">Time:</label>
+        <input
+          id="time"
+          type="time"
+          value={time}
+          onChange={(e) => setTime(e.target.value)}
+          required
+        />
+      </div>
+      <Button type="submit" buttonType="primary">
+        Add Class
+      </Button>
+    </form>
+  );
+};
+
+export default AddClassForm;


### PR DESCRIPTION
## Summary
- enable creation of new classes with an `AddClassForm` component
- persist classes in localStorage and load them on start
- update ClassesPage to use the new form

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875403d082c833395de4a03925ad537